### PR TITLE
- Feature: make optional the junitReport directory

### DIFF
--- a/lib/docs.js
+++ b/lib/docs.js
@@ -13,6 +13,7 @@ var params = require('./params'),
 var docs = {
 
     cmdOptions : {
+        "junitReport" : "write junit report at the end",
         "initShot": "from shot : "+config.cmd+" -i <shotname>",
         "endShot": "to shot : "+config.cmd+" -e <shotname>",
         "help" : "shows detailed info for command, <name> of straw or -s <shot> name shot : "+config.cmd+" -h <strawname>",

--- a/lib/params.js
+++ b/lib/params.js
@@ -2,6 +2,7 @@ var nopt = require("nopt");
 
 var knownOpts = {
         "help" : Boolean,
+        "junitReport" : Boolean,
         "shot" : Boolean,
         "commands" : ["all","straws","shots"],
         "list" : ["all","recipes","straws","shots","repoTypes"],
@@ -11,6 +12,7 @@ var knownOpts = {
         "level" : [ "debug", "verbose", "warning" ]
     },
     shortHands = {
+        "u": ["--junitReport"],
         "i": ["--initShot"],
         "e": ["--endShot"],
         "h" : ["--help"],

--- a/lib/shot.js
+++ b/lib/shot.js
@@ -6,6 +6,7 @@ var logger = require("./logger"),
     runSequence = require('run-sequence'),
     async = require('async'),
     inquirer = require('inquirer'),
+    //Mocha = require('mocha'),
     spawn = require('child_process').spawn,
     spawnSync = require('child_process').spawnSync;
 
@@ -20,6 +21,20 @@ var Shot = function(runner){
     this.logger = logger;
     return this;
 };
+
+/*  For the mocha execution
+var mocha = new Mocha({
+    reporter: 'mocha-junit-reporter',
+    reporterOptions: {
+        mochaFile: path.join(config.junitDir,"pisco-unit.xml")
+    }
+});
+mocha.files = [path.join(config.modulesDir.module,"lib","tests","execution.js")];
+var runner = mocha.run();
+runner.on("end",function(){
+    cb(runner.failures);
+});
+*/
 
 Shot.prototype.do = function(stage){
     var operation = this.runner[stage];

--- a/lib/sour.js
+++ b/lib/sour.js
@@ -7,7 +7,6 @@ var docs = require("./docs"),
     config = require("./config"),
     shooter = require("./shooter"),
     params = require("./params"),
-    Mocha = require('mocha'),
     sipper = require("./sipper"),
     logger = require("./logger");
 
@@ -28,38 +27,28 @@ var Sour = function(){
             logger.trace("#green","sour:gush","params:",params.argv.remain);
 
             var xresolve = function(){
-                /*mochaInterceptor(function(failures){
-                    if (failures===0) {
-                        console.log("-------OK--------");*/
-                        resolve.apply(this, arguments);
-                    /*}else {
-                        console.log("-------ERROR--------");
-                        reject.apply(this, arguments);
-                    }
-                });*/
+                var isOk = finalCheck();
+                if (isOk)
+                    resolve.apply(this, arguments);
+                else
+                    reject.apply(this, arguments);
             };
 
             var xreject = function(){
-                //mochaInterceptor(function(){
-                  //  console.log("-------ERROR XREJECT--------");
-                    reject.apply(this,arguments);
-                //});
+                finalCheck();
+                reject.apply(this,arguments);
             };
 
-            var mochaInterceptor = function(cb){
-                logger.info("#magenta","Write results in junit format at", path.join(config.junitDir,"pisco-unit.xml"));
-                var mocha = new Mocha({
-                    reporter: 'mocha-junit-reporter',
-                    reporterOptions: {
-                        mochaFile: path.join(config.junitDir,"pisco-unit.xml")
-                    }
-                });
-                mocha.files = [path.join(config.modulesDir.module,"lib","tests","execution.js")];
-                var runner = mocha.run();
-                runner.on("end",function(){
-                   cb(runner.failures);
-                });
+            var finalCheck = function(){
+                logger.info("#magenta","finalCheck...");
+                if (params.junitReport)
+                    writeJunitXml();
+                return true;
             };
+
+            var writeJunitXml = function(){
+                logger.info("#magenta","Write results in junit format at", path.join(config.junitDir,"pisco-unit.xml"));
+            }
 
             try {
                 var normal = check(reject);


### PR DESCRIPTION
Solo se generará el directorio $junitDir cuando se pase la opción -u 

De momento no se está generando esta carpeta de ninguna manera, puesto que se va a hacer otra feature que cambie la manera de escribir el fichero junitXml sin usar mocha. La feature para que esto sea posible se hará en breve por lo tanto necesito aceptar el pull request rápidamente. ;)
