### PR TITLE
Feature/config refactor

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -157,7 +157,7 @@ var getConfig = function() {
             if (!shots[shot][type])
                 shots[shot][type] = {};
 
-            shots[shot][type].params = params;
+            shots[shot][type].params = mergeObject(params, shots[shot][type].params);
 
         }
     };
@@ -189,7 +189,7 @@ var getConfig = function() {
                 var strawConfig = safeRequire(path.join(dir,'straws',straw,'straw.json'));
 
                 if (strawConfig.params)
-                    configAdded.straws[straw].params = strawConfig.params;
+                    configAdded.straws[straw].params = mergeObject(configAdded.straws[straw].params,strawConfig.params);
 
                 if (strawConfig.shots)
                     configAdded.straws[straw].shots = strawConfig.shots;
@@ -202,14 +202,13 @@ var getConfig = function() {
                     }
             }
 
-        logger.trace("#green","Effective config:",JSON.stringify(config));
         config = mergeObject(config,configAdded);
     }
 
     config.getShotParams = function(normal){
         for (var shot in this.shots){
             if (shot===normal.name && this.shots[shot][normal.repoType]){
-                return this.shots[shot][normal.repoType].params;
+                return mergeObject(this.shots[shot][normal.repoType].params,this.shots[shot].params);
             }
         }
         return {};
@@ -220,7 +219,9 @@ var getConfig = function() {
             if (straw===normal.name){
                 for (var shot in this.straws[straw].shots){
                     if (shot===normalShot.name && this.straws[straw].shots[shot][normalShot.repoType]){
-                        return mergeObject(this.straws[straw].shots[shot][normalShot.repoType].params,this.straws[straw].params);
+                        var params = mergeObject(this.straws[straw].params,this.straws[straw].shots[shot].params);
+                        params = mergeObject(params, this.straws[straw].shots[shot][normalShot.repoType].params);
+                        return params;
                     }
                 }
             }

--- a/lib/config.js
+++ b/lib/config.js
@@ -218,9 +218,10 @@ var getConfig = function() {
         for (var straw in this.straws){
             if (straw===normal.name){
                 for (var shot in this.straws[straw].shots){
-                    if (shot===normalShot.name && this.straws[straw].shots[shot][normalShot.repoType]){
+                    if (shot===normalShot.name){
                         var params = mergeObject(this.straws[straw].params,this.straws[straw].shots[shot].params);
-                        params = mergeObject(params, this.straws[straw].shots[shot][normalShot.repoType].params);
+                        if (this.straws[straw].shots[shot][normalShot.repoType])
+                            params = mergeObject(params, this.straws[straw].shots[shot][normalShot.repoType].params);
                         return params;
                     }
                 }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -75,6 +75,14 @@ var logger = {
     trace: function () {
         if (gLevel >= 3)
             console.info.apply(this,this.prettyPrint(arguments));
+    },
+    debug: function () {
+        if (gLevel >= 4)
+            console.info.apply(this,this.prettyPrint(arguments));
+    },
+    silly: function () {
+        if (gLevel >= 5)
+            console.info.apply(this,this.prettyPrint(arguments));
     }
 };
 

--- a/lib/shooter.js
+++ b/lib/shooter.js
@@ -106,7 +106,7 @@ var shooter = function(){
         var shot = {};
         for (var name in config.modulesDir){
             if (!name.startsWith('c_')) {
-                var filename = path.join(config.modulesDir[name], "shots", normal.name, normal.repoType, "shot.js");
+                var filename = path.join(config.modulesDir[name], "shots", normal.name.indexOf(':')>=0?normal.name.split(':')[0]:normal.name, normal.repoType, "shot.js");
                 logger.trace("#green", "shooter:load", "trying", "[", name, "]", filename, "...");
                 try {
                     if (fs.statSync(filename)) {

--- a/shots/test/recipe/shot.js
+++ b/shots/test/recipe/shot.js
@@ -4,7 +4,7 @@ var piscosour = require('../../..'),
     Shot = piscosour.Shot;
 
 var shot = new Shot({
-    description : "Brief description of shot",
+    description : "TEST Brief description of shot",
 
     config : function(resolve){
         shot.logger.info("#magenta","config","Preparing params for main execution");
@@ -12,6 +12,7 @@ var shot = new Shot({
 
     run : function(resolve){
         shot.logger.info("#magenta","run","Run main execution");
+        shot.logger.info("execution: ",shot.runner.params.execution);
     },
 
     prove : function(resolve){

--- a/shots/test2/recipe/shot.js
+++ b/shots/test2/recipe/shot.js
@@ -10,8 +10,10 @@ var shot = new Shot({
         shot.logger.info("#magenta","check","Check all pre-requisites for the execution");
     },
 
-    config : function(resolve){
+    config : function(resolve, reject){
         shot.logger.info("#magenta","config","Preparing params for main execution");
+        if (shot.runner.params.saludo!=="hola")
+            reject("ERROR: "+JSON.stringify(shot.runner.params));
     },
 
     run : function(resolve, reject){

--- a/straws/test/straw.json
+++ b/straws/test/straw.json
@@ -13,7 +13,16 @@
         }
       }
     },
-    "test" : {},
+    "test:1" : {
+      "params" :  {
+        "execution" :  "PRIMERA"
+      }
+    },
+    "test:2" : {
+      "params" :  {
+        "execution" :  "SEGUNDA"
+      }
+    },
     "testint" :{
       "type" : "straw"
     }

--- a/straws/test/straw.json
+++ b/straws/test/straw.json
@@ -1,7 +1,18 @@
 {
-  "params" : {},
+  "params" : {
+    "saludo": "hola2"
+  },
   "shots" : {
-    "test2" : {},
+    "test2" : {
+      "params": {
+        "saludo": "hola1"
+      },
+      "recipe" : {
+        "params": {
+          "saludo": "hola"
+        }
+      }
+    },
     "test" : {},
     "testint" :{
       "type" : "straw"


### PR DESCRIPTION
soluciona los issues #28 y #29 

para poder ejecutar dos veces el mismo shot y mantener compatibilidad hacia atrás se permite introducir una variación en la definición del shot en el fichero straw.js

al llamar al shot en straw.js se le puede añadir : + "lo que sea" esto permite usar dos veces el mismo shot.

``` js
{
  "shots" : {
    "test2" : {},
    "test:1" : {
      "params" :  {
        "execution" :  "PRIMERA"
      }
    },
    "test:2" : {
      "params" :  {
        "execution" :  "SEGUNDA"
      }
    },
    "testint" :{
      "type" : "straw"
    }
  }
}
```

test:

pisco test (deberá ejecutar dos veces test con el parámetro execution con los dos valores)
