### PR TITLE
Fix/ignore shot when wrong in straw

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -135,10 +135,12 @@ var Config = function() {
         logger.silly("#green","config:getShot -in-", normalIn);
         var normal = _normalShot(normalIn);
         var globalShot = _getGen(normal,'shots');
-        var shot = globalShot.default;
-        shot = _mergeObject(shot,globalShot[normal.repoType]);
-        logger.silly("#green","config:getShot -out-", shot);
-        return shot;
+        if (globalShot) {
+            var shot = globalShot.default;
+            shot = _mergeObject(shot, globalShot[normal.repoType]);
+            logger.silly("#green", "config:getShot -out-", shot);
+            return shot;
+        }
     };
 
     /**

--- a/straws/test/straw.json
+++ b/straws/test/straw.json
@@ -7,7 +7,7 @@
     "saludo": "holastraw"
   },
   "shots" : {
-    "tests2" : {
+    "test2" : {
       "params": {
         "saludo": "holadefault"
       },

--- a/straws/test/straw.json
+++ b/straws/test/straw.json
@@ -7,7 +7,7 @@
     "saludo": "holastraw"
   },
   "shots" : {
-    "test2" : {
+    "tests2" : {
       "params": {
         "saludo": "holadefault"
       },


### PR DESCRIPTION
Resolve issue #52 

Now this is the displayed error:

```
[17:39:19] Your repository type is: [ component ]
[17:39:19] Sipping straw [ test ] shots: [ 'tests2', 'test:1', 'test:2', 'testint' ]
[17:39:19] Piscosour shot [ component:tests2 ]
[17:39:19] sipper Shot error stops the straw!! ERROR: Shot "tests2" is not defined for repository Type: "component"
[17:39:19] finalCheck...
```
