### PR TITLE
Feature/no constructors

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -222,9 +222,10 @@ var Config = function() {
         logger.trace("#green", "config:load", "[", normal.name, "]", filename, "...");
 
         if (fsUtils.exists(filename)){
-            shot = _mergeObject(require(filename), shot);
+            shot = new Shot(_mergeObject(require(filename), shot));
             shot.runner.name = normal.origName;
-            shot.runner.params = normal.params;
+            shot.params = normal.params;
+            //TODO: OJO con esto! 
         }
 
         logger.silly("#green","config:loadOne -out-", shot);

--- a/lib/shot.js
+++ b/lib/shot.js
@@ -18,6 +18,7 @@ var logger = require("./logger"),
 var Shot = function(runner){
     this.logger = logger;
     this.plugins = {};
+    this.runner = {};
     
     for (var name in runner) {
       if (typeof runner[name] === 'function') {

--- a/lib/shot.js
+++ b/lib/shot.js
@@ -16,9 +16,16 @@ var logger = require("./logger"),
  * @constructor
  */
 var Shot = function(runner){
-    this.runner = runner;
     this.logger = logger;
     this.plugins = {};
+    
+    for (var name in runner) {
+      if (typeof runner[name] === 'function') {
+        this.runner[name] = runner[name].bind(this);
+      } else {
+        this.runner[name] = runner[name];
+      }
+    }
     return this;
 };
 


### PR DESCRIPTION
We now avoid the use of constructor function when declaring a Shot. Module config is the responsible for instantiating a new Shot, and the client Shot should only declare the runner object to be used during the construction.
