### PR TITLE
fix(launcher/plugin): call isWin function correctly

### DIFF
--- a/plugins/launcher/plugin.js
+++ b/plugins/launcher/plugin.js
@@ -9,7 +9,7 @@ module.exports = {
     addons: {
         sh: function (cmdsh, reject, loud) {
             var result;
-            if (this.isWin) {
+            if (this.isWin()) {
                 result = this.executeSync("cmd", ["/c", cmdsh], reject, loud);
             }else{
                 result = this.executeSync("sh", ["-c", cmdsh], reject, loud);


### PR DESCRIPTION
Correctly calling the function, so sh method can work again.
